### PR TITLE
Update to flutter 3 | based on exo_player_2_17 branch

### DIFF
--- a/lib/cached_video_player.dart
+++ b/lib/cached_video_player.dart
@@ -573,7 +573,7 @@ class _VideoAppLifeCycleObserver extends Object with WidgetsBindingObserver {
   final VideoPlayerController _controller;
 
   void initialize() {
-    WidgetsBinding.instance!.addObserver(this);
+    WidgetsBinding.instance.addObserver(this);
   }
 
   @override
@@ -593,7 +593,7 @@ class _VideoAppLifeCycleObserver extends Object with WidgetsBindingObserver {
   }
 
   void dispose() {
-    WidgetsBinding.instance!.removeObserver(this);
+    WidgetsBinding.instance.removeObserver(this);
   }
 }
 


### PR DESCRIPTION
Fix 
```
lib/cached_video_player.dart:576:20: Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.
```
problems in flutter 3 